### PR TITLE
Use slideover from tailwindcss-stimulus-components for navigations

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,24 @@
  *= require_tree .
  *= require_self
  */
+
+dialog.slideover[open] {
+  animation: slide-in-from-right 200ms forwards ease-in-out;
+}
+
+dialog.slideover[closing] {
+  pointer-events: none;
+  animation: slide-out-to-right 200ms forwards ease-in-out;
+}
+
+@keyframes slide-in-from-right {
+  from {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes slide-out-to-right {
+  to {
+    transform: translateX(100%);
+  }
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -38,6 +38,10 @@ trix-toolbar {
     @apply p-3 bg-zinc-800 border border-zinc-700 text-base text-zinc-100 rounded-lg hover:bg-zinc-700 transition first-letter:capitalize cursor-pointer;
   }
 
+  .btn-ghost {
+    @apply flex items-center py-2 px-4 text-base text-zinc-100 rounded-lg hover:bg-zinc-800 transition first-letter:capitalize cursor-pointer;
+  }
+
   .btn-danger {
     @apply p-3 bg-red-500 text-base text-zinc-100 rounded-lg hover:bg-red-600 transition first-letter:capitalize cursor-pointer;
   }
@@ -67,7 +71,11 @@ trix-toolbar {
   }
 
   .input {
-    @apply w-full p-3 border bg-zinc-800 border-zinc-700 text-sm text-zinc-300 rounded-lg focus:outline-none focus:ring-0 focus:ring-offset-0 focus:border-violet-900;
+    @apply w-full px-3 py-2 border bg-zinc-800 border-zinc-700 text-sm text-zinc-300 rounded-lg focus:outline-none focus:ring-0 focus:ring-offset-0 focus:border-violet-900;
+  }
+
+  .input-label {
+    @apply text-zinc-100 text-sm font-medium;
   }
 
   .field-error {

--- a/app/components/common/avatar/component.html.erb
+++ b/app/components/common/avatar/component.html.erb
@@ -1,5 +1,5 @@
 <% if user.avatar.attached? %>
-  <%= image_tag(user.avatar, class: "#{avatar_size} rounded-full #{class_name}") %>
+  <%= image_tag(user.avatar, class: "#{avatar_size} max-w-none rounded-full #{class_name}") %>
 <% else %>
   <%= icon("user_avatar", class_name: "#{avatar_size} rounded-full #{class_name}", variant: :outline) %>
 <% end %>

--- a/app/components/common/avatar/component.rb
+++ b/app/components/common/avatar/component.rb
@@ -7,9 +7,15 @@ class Common::Avatar::Component < ApplicationComponent
     {
       "sm" => "size-5",
       "md" => "size-8",
-      "lg" => "size-16",
-      "xl" => "size-24",
-      "2xl" => "size-32"
+      "lg" => "size-12",
+      "xl" => "size-16",
+      "2xl" => "size-24",
+      "3xl" => "size-32",
+      "4xl" => "size-40",
+      "5xl" => "size-48",
+      "6xl" => "size-56",
+      "7xl" => "size-64",
+      "8xl" => "size-72"
     }[size]
   end
 end

--- a/app/components/common/slideover/component.html.erb
+++ b/app/components/common/slideover/component.html.erb
@@ -1,0 +1,7 @@
+<div data-controller="slideover">
+  <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 ml-auto w-96 p-8 backdrop:bg-black/80">
+    <%= content %>
+    <button autofocus data-action="slideover#close" class="px-2.5 py-1 bg-blue-500 text-white text-sm rounded">Close</button>
+  </dialog>
+  <%= trigger %>
+</div>

--- a/app/components/common/slideover/component.html.erb
+++ b/app/components/common/slideover/component.html.erb
@@ -1,7 +1,15 @@
-<div data-controller="slideover">
-  <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 ml-auto w-96 p-8 backdrop:bg-black/80">
-    <%= content %>
-    <button autofocus data-action="slideover#close" class="px-2.5 py-1 bg-blue-500 text-white text-sm rounded">Close</button>
+<div class="flex" data-controller="slideover">
+  <dialog
+    class="slideover h-full max-h-full m-0 ml-auto w-80 px-4 py-8 rounded-l-lg bg-zinc-900 backdrop:bg-black/20"
+    data-slideover-target="dialog"
+    data-action="click->slideover#backdropClose"
+    >
+    <div class="flex flex-col gap-4 w-full">
+      <%= button_tag(class: "btn-cancel btn-md p-1.5 ml-auto", autofocus: true, data: { action: "slideover#close" }) do %>
+        <%= icon("close", class_name: "size-5") %>
+      <% end %>
+      <%= content %>
+    </div>
   </dialog>
   <%= trigger %>
 </div>

--- a/app/components/common/slideover/component.html.erb
+++ b/app/components/common/slideover/component.html.erb
@@ -1,11 +1,11 @@
 <div class="flex" data-controller="slideover">
   <dialog
-    class="slideover h-full max-h-full m-0 ml-auto w-80 px-4 py-8 rounded-l-lg bg-zinc-900 backdrop:bg-black/20"
+    class="slideover h-full max-h-full m-0 ml-auto w-80 px-4 py-8 rounded-l-lg bg-zinc-900 border-l border-zinc-800 backdrop:bg-black/20"
     data-slideover-target="dialog"
     data-action="click->slideover#backdropClose"
     >
-    <div class="flex flex-col gap-4 w-full">
-      <%= button_tag(class: "btn-cancel btn-md p-1.5 ml-auto", autofocus: true, data: { action: "slideover#close" }) do %>
+    <div class="flex flex-col gap-3 w-full">
+      <%= button_tag(class: "btn-ghost btn-md p-1.5 ml-auto", autofocus: true, data: { action: "slideover#close" }) do %>
         <%= icon("close", class_name: "size-5") %>
       <% end %>
       <%= content %>

--- a/app/components/common/slideover/component.rb
+++ b/app/components/common/slideover/component.rb
@@ -1,0 +1,9 @@
+class Common::Slideover::Component < ApplicationComponent
+  include Common::Slideover
+
+  option :class_name, Types::String, optional: true
+
+  renders_one :trigger, lambda { |variant: :primary, id: '', class_name: ''|
+                          Trigger::Component.new(id:, class_name:, variant:)
+                        }
+end

--- a/app/components/common/slideover/trigger/component.html.erb
+++ b/app/components/common/slideover/trigger/component.html.erb
@@ -1,0 +1,3 @@
+<%= button_tag(class: "#{style}", data: { action: "slideover#open", target: "dialog" }) do %>
+  <%= content %>
+<% end %>

--- a/app/components/common/slideover/trigger/component.rb
+++ b/app/components/common/slideover/trigger/component.rb
@@ -1,0 +1,16 @@
+class Common::Slideover::Trigger::Component < ApplicationComponent
+  include Common::Slideover::Trigger
+
+  option :id, Types::String, optional: true
+  option :class_name, Types::String, optional: true
+  option :variant, Types::Symbol.enum(:primary, :unstyled), default: -> { :primary }
+
+  def style
+    case variant
+    when :primary
+      'btn-primary btn-md'
+    when :unstyled
+      ''
+    end
+  end
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -7,6 +7,7 @@ import {
   Tabs,
   Toggle,
 } from "tailwindcss-stimulus-components"
+import Slideover from "./slideover_controller"
 import { setupConfirmMethod } from "../turbo_confirm_logic"
 
 const application = Application.start()
@@ -17,6 +18,7 @@ application.register("dropdown", Dropdown)
 application.register("modal", Modal)
 application.register("tabs", Tabs)
 application.register("toggle", Toggle)
+application.register("slideover", Slideover)
 
 setupConfirmMethod()
 

--- a/app/javascript/controllers/comment_form_controller.js
+++ b/app/javascript/controllers/comment_form_controller.js
@@ -10,26 +10,43 @@ export default class extends Controller {
     this.setupTurboSubmitEventListener()
   }
 
+  disconnect() {
+    this.teardownFormEventListener()
+    this.teardownTurboSubmitEventListener()
+  }
+
   setOnLoad() {
     this.initialValue = this.getCommentInputValue().trim()
     this.updateButtonsState()
   }
 
   setupFormEventListener() {
-    this.commentInputTarget.addEventListener("trix-change", () => {
-      this.updateButtonsState()
-    })
+    this.trixChangeHandler = () => this.updateButtonsState()
+    this.commentInputTarget.addEventListener(
+      "trix-change",
+      this.trixChangeHandler,
+    )
+  }
+
+  teardownFormEventListener() {
+    this.commentInputTarget.removeEventListener(
+      "trix-change",
+      this.trixChangeHandler,
+    )
   }
 
   setupTurboSubmitEventListener() {
-    document.addEventListener("turbo:submit-end", (event) => {
+    this.turboSubmitEndHandler = (event) => {
       this.resetForm()
-
-      console.log(this.formTarget.parentElement)
       if (this.formTarget.parentElement.id === "content_reply") {
         this.closeForm(event)
       }
-    })
+    }
+    document.addEventListener("turbo:submit-end", this.turboSubmitEndHandler)
+  }
+
+  teardownTurboSubmitEventListener() {
+    document.removeEventListener("turbo:submit-end", this.turboSubmitEndHandler)
   }
 
   updateButtonsState() {

--- a/app/javascript/controllers/slideover_controller.js
+++ b/app/javascript/controllers/slideover_controller.js
@@ -51,10 +51,9 @@ export default class extends Controller {
   }
 
   handleKeyDown(event) {
-    // Sprawdź, czy naciśnięto klawisz Escape
     if (event.key === "Escape") {
-      event.preventDefault() // Zapobiegnij domyślnej akcji przeglądarki
-      this.close() // Zamknij modal
+      event.preventDefault()
+      this.close()
     }
   }
 }

--- a/app/javascript/controllers/slideover_controller.js
+++ b/app/javascript/controllers/slideover_controller.js
@@ -1,0 +1,60 @@
+import { Controller } from "@hotwired/stimulus"
+export default class extends Controller {
+  static targets = ["dialog"]
+  static values = {
+    open: Boolean,
+  }
+
+  connect() {
+    if (this.openValue) this.open()
+    document.addEventListener("turbo:before-cache", this.beforeCache.bind(this))
+    document.addEventListener("keydown", this.handleKeyDown.bind(this))
+  }
+
+  disconnect() {
+    document.removeEventListener(
+      "turbo:before-cache",
+      this.beforeCache.bind(this),
+    )
+    document.removeEventListener("keydown", this.handleKeyDown.bind(this))
+  }
+
+  open() {
+    this.dialogTarget.showModal()
+  }
+
+  close() {
+    this.dialogTarget.setAttribute("closing", "")
+
+    Promise.all(
+      this.dialogTarget.getAnimations().map((animation) => animation.finished),
+    ).then(() => {
+      this.dialogTarget.removeAttribute("closing")
+      this.dialogTarget.close()
+    })
+  }
+
+  backdropClose(event) {
+    if (event.target.nodeName == "DIALOG") this.close()
+  }
+
+  show() {
+    this.open()
+  }
+
+  hide() {
+    this.close()
+  }
+
+  beforeCache() {
+    this.close()
+  }
+
+  handleKeyDown(event) {
+    // Sprawdź, czy naciśnięto klawisz Escape
+    if (event.key === "Escape") {
+      event.preventDefault() // Zapobiegnij domyślnej akcji przeglądarki
+      this.close() // Zamknij modal
+    }
+  }
+}

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -13,27 +13,31 @@
           </li>
         <% end %>
         <% if user_signed_in? %>
-          <%= render(Common::Dropdown::Component.new(position: 'left', menu_class: "top-16")) do |c| %>
-            <% c.with_button(class_name: "p-0 rounded-full") do %>
+          <%= render(Common::Slideover::Component.new) do |c| %>
+            <% c.with_trigger(variant: :unstyled) do %>
               <%= render(Common::Avatar::Component.new(user: current_user)) %>
             <% end %>
-            <div class="px-4 pt-2 pb-3 border-b border-zinc-700">
-              <p><%= current_user.name %></p>
+            <div class="flex items-center gap-3 pt-2 pb-3 border-b border-zinc-800">
+              <%= render(Common::Avatar::Component.new(user: current_user, size: "md")) %>
+              <div class="flex flex-col">
+                <p class="text-sm text-zinc-100"><%= current_user.name %></p>
+                <p class="text-xs text-zinc-500"><%= current_user.email %></p>
+              </div>
             </div>
-            <%= link_to(dashboard_root_path, class: "menu-item") do %>
+            <%= link_to(dashboard_root_path, class: "menu-item p-1") do %>
               <%= icon("dashboard", class_name: "w-5 h-5", title: "Dashboard", variant: :outline) %>
               <span>dashboard</span>
             <% end %>
-            <%= link_to(user_profile_path(current_user), class: "menu-item") do %>
+            <%= link_to(user_profile_path(current_user), class: "menu-item p-1") do %>
               <%= icon("person", class_name: "w-5 h-5", title: "Profile", variant: :outline) %>
               <span>profile</span>
             <% end %>
-            <div class="border-t border-zinc-700"></div>
-            <%= link_to(settings_profile_path, class: "menu-item") do %>
+            <div class="border-t border-zinc-800"></div>
+            <%= link_to(settings_profile_path, class: "menu-item p-1") do %>
               <%= icon("settings", class_name: "w-5 h-5", title: "Settings", variant: :outline) %>
               <span>settings</span>
             <% end %>
-            <%= button_to(destroy_user_session_path, method: :delete, class: "menu-item") do %>
+            <%= button_to(destroy_user_session_path, method: :delete, class: "menu-item p-1") do %>
               <%= icon("logout", class_name: "w-5 h-5", title: "Logout") %>
               <span>logout</span>
             <% end %>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -24,23 +24,39 @@
                 <p class="text-xs text-zinc-500"><%= current_user.email %></p>
               </div>
             </div>
-            <%= link_to(dashboard_root_path, class: "menu-item p-1") do %>
-              <%= icon("dashboard", class_name: "w-5 h-5", title: "Dashboard", variant: :outline) %>
-              <span>dashboard</span>
-            <% end %>
-            <%= link_to(user_profile_path(current_user), class: "menu-item p-1") do %>
-              <%= icon("person", class_name: "w-5 h-5", title: "Profile", variant: :outline) %>
-              <span>profile</span>
-            <% end %>
-            <div class="border-t border-zinc-800"></div>
-            <%= link_to(settings_profile_path, class: "menu-item p-1") do %>
-              <%= icon("settings", class_name: "w-5 h-5", title: "Settings", variant: :outline) %>
-              <span>settings</span>
-            <% end %>
-            <%= button_to(destroy_user_session_path, method: :delete, class: "menu-item p-1") do %>
-              <%= icon("logout", class_name: "w-5 h-5", title: "Logout") %>
-              <span>logout</span>
-            <% end %>
+            <div class="flex flex-col gap-2">
+              <%= link_to(
+                dashboard_root_path,
+                class: "menu-item p-2 hover:bg-zinc-800 #{request.fullpath.include?(dashboard_root_path) ? 'bg-zinc-800' : ''}"
+              ) do %>
+                <%= icon("dashboard", class_name: "w-5 h-5", title: "Dashboard", variant: :outline) %>
+                <span>dashboard</span>
+              <% end %>
+              <%= link_to(
+                user_profile_path(current_user),
+                class: "menu-item p-2 hover:bg-zinc-800 #{request.fullpath.include?(user_profile_path(current_user)) ? 'bg-zinc-800' : ''}"
+              ) do %>
+                <%= icon("person", class_name: "w-5 h-5", title: "Profile", variant: :outline) %>
+                <span>profile</span>
+              <% end %>
+            </div>
+            <div class="flex flex-col gap-2 pt-3 border-t border-zinc-800">
+              <%= link_to(
+                settings_profile_path,
+                class: "menu-item p-2 hover:bg-zinc-800 #{request.fullpath.include?(settings_profile_path) ? 'bg-zinc-800' : ''}"
+              ) do %>
+                <%= icon("settings", class_name: "w-5 h-5", title: "Settings", variant: :outline) %>
+                <span>settings</span>
+              <% end %>
+              <%= button_to(
+                destroy_user_session_path,
+                method: :delete,
+                class: "menu-item p-2 hover:bg-zinc-800"
+              ) do %>
+                <%= icon("logout", class_name: "w-5 h-5", title: "Logout") %>
+                <span>logout</span>
+              <% end %>
+            </div>
           <% end %>
         <% else %>
           <div class="flex items-center gap-3">

--- a/app/views/users_profiles/show.html.erb
+++ b/app/views/users_profiles/show.html.erb
@@ -1,6 +1,6 @@
 <section class="flex flex-col gap-4 flex-10 max-w-full lg:w-full lg:grid lg:grid-cols-12 lg:grid-flow-col lg:gap-12 py-4 lg:py-12 lg:max-w-[1200px] mx-auto">
   <aside class="flex flex-col gap-4 lg:h-max lg:sticky lg:top-28 lg:col-start-9 lg:col-end-13">
-    <%= render(Common::Avatar::Component.new(user: @user, size: "2xl")) %>
+    <%= render(Common::Avatar::Component.new(user: @user, size: "5xl")) %>
     <h1 class="text-lg font-medium"><%= @user.name %></h1>
     <p><%= @user.bio %></p>
     <div class="flex items-center gap-2 text-sm text-zinc-200">


### PR DESCRIPTION
## Changes:
- update `avatar` component,
- create `slideover` component,
- refactor 'comment_form' stimulus controller,

## SS
![obraz](https://github.com/tomasz-klos/blog/assets/65667822/bb9be7a5-10bb-4d50-aefa-70a6804a872a)
